### PR TITLE
curl response >= 400, fail with code 22

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -33,7 +33,7 @@ get_files() {
 
 artifactory_get_folder_contents() {
   local artifacts_url=$1
-  curl $1
+  curl -f $1
 }
 
 # retrieve current from artifactory

--- a/assets/in
+++ b/assets/in
@@ -76,7 +76,7 @@ fi
 
 args_url="$endpoint$repository/$file"
 
-# echo $args_security "-O" "$args_url"
-curl $args_security "-O" "$args_url"
+# echo -f $args_security "-O" "$args_url"
+curl -f $args_security "-O" "$args_url"
 
 echo $file_json | jq '.[].version | {version: {version: .}}' >&3

--- a/assets/out
+++ b/assets/out
@@ -69,8 +69,8 @@ trueValue="true"
 
 # echo "########## $filename, $file"
 
-# echo $args_security "-T $abs_file $args_url "
-curl $args_security "-T$abs_file" "$args_url"
+# echo -f $args_security "-T $abs_file $args_url "
+curl -f $args_security "-T$abs_file" "$args_url"
 
 
 # echo $file $regex


### PR DESCRIPTION
Since all assets are `set -e`, `curl -f` will cause the script
to stop and return code 22 if http response code >= 400 is received.
As is, the script does not end immediately on bad curl requests.

close #3
supercede #15

-f, --fail
  (HTTP) Fail silently (no output at all) on server errors. This is
mostly done to better enable scripts etc to better deal with failed
attempts.  In  normal  cases when  an  HTTP  server  fails to deliver a
document, it returns an HTML document stating so (which often also
describes why and more). This flag will prevent curl from outputting
that and return error 22.

  This method is not fail-safe and there are occasions where
non-successful response codes will slip through, especially when
authentication is  involved  (response codes 401 and 407).
...
  22 HTTP page not retrieved. The requested url was not found or
returned another error with the HTTP error code being 400 or above.
This return code only appears if -f, --fail is used.